### PR TITLE
PPH-13 Add initial styles and documentation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ themes][source].
 
 This repository follows the [GitHub Flow guidelines][github-flow].
 
+## License
+
+```text
+   Copyright 2017 Communication Services for the Deaf, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```
+
 ## Usage
 
 After installation updates are applied sequentially based on commit hierarchy.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,156 @@
 # pph-theme
+
 This is the Discourse theme for the Public Policy Hub (public-policy.csd.org).
+
+Documentation for this repo was provided from [How to develop custom
+themes][source].
+
+This repository follows the [GitHub Flow guidelines][github-flow].
+
+## Usage
+
+After installation updates are applied sequentially based on commit hierarchy.
+In normal development flow this won't be a problem. However, If you attempt to
+reset or checkout an older commit it won't work because Discourse will presume
+that the commit is already there and not provide you the opportunity to update.
+To do so you must move forward in the history (perhaps in the worse case using
+an `--allow-empty` commit).
+
+### Production
+
+For the initial install login to Discourse as an admin and navigate to the Admin
+menu then the Customize section. There is an **Import** button. When you click
+on it a modal popup will ask for **From the web** when selected enter the
+following URL:
+
+    https://github.com/C-S-D/pph-theme.git
+
+From here you can set the **CSD Public Policy Hub** theme as the default for
+the site.
+
+As there are changes to this repository those changes can be reflected by
+clicking that theme in the **Admin | Customize | Themes** section and then in
+the **Custom CSS/HTML** section there is a button labeled **Check for Updates**.
+
+Discourse does not subscribe to any branch which means it defaults to the main
+one provided by GitHub (in this case `master`).
+
+### Development
+
+In development you can use the same steps as above but instead of pointing to
+GitHub you can point to your local git repo. To do so you will have to start a
+Git daemon. While *in this repo* run the following command:
+
+```console
+$ git daemon --verbose --export-all --base-path=. --reuseaddr ./.git
+```
+
+This will provide you an import URL of:
+
+| Running Locally        | Running in Vagrant    |
+|------------------------|-----------------------|
+| `git://127.0.0.1/.git` | `git://10.0.2.2/.git` |
+
+You only need this running at the time you click the **Check for Updates**
+button. When using the Git Daemon, Discourse will presume the latest is based on
+the current branch that is checked out when the daemon is started. This means
+updates can happen as long as they follow the sequential caveat described above.
+
+A good workflow in development is to make a WIP commit each time you want to
+check the changes and continue to sequentially make more as you develop. Then
+when satisfied rebase the branch back into well formed commits then push that
+for PR.
+
+## Base Pallet
+
+|                                                          | Name             | Value     |
+|----------------------------------------------------------|------------------|-----------|
+| ![#0575BB](https://placehold.it/15/0575BB/000000?text=+) | `pph-blue`       | `#0575BB` |
+| ![#1B9AD6](https://placehold.it/15/1B9AD6/000000?text=+) | `pph-blue-light` | `#1B9AD6` |
+| ![#1D293F](https://placehold.it/15/1D293F/000000?text=+) | `pph-blue-dark`  | `#1D293F` |
+| ![#FFFFFF](https://placehold.it/15/FFFFFF/000000?text=+) | `pph-white`      | `#FFFFFF` |
+| ![#F7F7F7](https://placehold.it/15/F7F7F7/000000?text=+) | `pph-gray-light` | `#F7F7F7` |
+| ![#999999](https://placehold.it/15/999999/000000?text=+) | `pph-gray`       | `#999999` |
+| ![#4C4C4C](https://placehold.it/15/4C4C4C/000000?text=+) | `pph-gray-dark`  | `#4C4C4C` |
+| ![#333333](https://placehold.it/15/333333/000000?text=+) | `pph-black`      | `#333333` |
+
+## File Structure
+
+```text
+.
+├── about.json
+├── common/
+│   ├── common.scss
+│   ├── header.html
+│   ├── after_header.html
+│   ├── footer.html
+│   ├── head_tag.html
+│   ├── body_tag.html
+│   └── embedded.scss
+├── desktop/
+│   ├── desktop.scss
+│   ├── header.html
+│   ├── after_header.html
+│   ├── footer.html
+│   ├── head_tag.html
+│   └── body_tag.html
+└── mobile/
+    ├── mobile.scss
+    ├── header.html
+    ├── after_header.html
+    ├── footer.html
+    ├── head_tag.html
+    └── body_tag.html
+```
+
+### `about.json`
+
+A JSON document used for meta data such as theme name and color schemes.
+
+More detail is available on [How to develop custom themes][source].
+
+### `common/`
+
+Customizations that are common across both desktop and mobile. The files in
+this directory follows this naming convention:
+
+| Filename            | Description |
+|---------------------|-------------|
+| `common.scss`       | Main SCSS to use. Override default selectors here. |
+| `header.html`       | HTML content to include in the site header. |
+| `after_header.html` | HTML content to include after the site header. |
+| `footer.html`       | HTML content to include in the site footer. |
+| `head_tag.html`     | HTML content to include before the `</head>` tag. |
+| `body_tag.html`     | HTML content to include before the `</body>` tag. |
+| `embedded.scss`     | SCSS to include when a shared post is embedded via an IFRAME on other sites. |
+
+### `desktop/`
+
+Customizations that are specific to the desktop browser/screen size. The files
+in this directory follows this naming convention:
+
+| Filename            | Description |
+|---------------------|-------------|
+| `desktop.scss`      | Desktop only SCSS to use. Override default selectors here. |
+| `header.html`       | HTML content to include in the site header. |
+| `after_header.html` | HTML content to include after the site header. |
+| `footer.html`       | HTML content to include in the site footer. |
+| `head_tag.html`     | HTML content to include before the `</head>` tag. |
+| `body_tag.html`     | HTML content to include before the `</body>` tag. |
+
+### `mobile/`
+
+Customizations that are specific to mobile browsers/screen size. The files in
+this directory follows this naming convention:
+
+| Filename            | Description |
+|---------------------|-------------|
+| `mobile.scss`       | Mobile only SCSS to use. Override default selectors here. |
+| `header.html`       | HTML content to include in the site header. |
+| `after_header.html` | HTML content to include after the site header. |
+| `footer.html`       | HTML content to include in the site footer. |
+| `head_tag.html`     | HTML content to include before the `</head>` tag. |
+| `body_tag.html`     | HTML content to include before the `</body>` tag. |
+
+[source]: https://meta.discourse.org/t/how-to-develop-custom-themes/60848
+[github-flow]: https://guides.github.com/introduction/flow/

--- a/about.json
+++ b/about.json
@@ -1,0 +1,18 @@
+{
+  "name": "CSD Public Policy Hub",
+  "about_url": "https://github.com/C-S-D/pph-theme/blob/master/README.md",
+  "color_schemes": {
+    "CSD Public Policy Hub": {
+      "primary": "333333",
+      "secondary": "ffffff",
+      "tertiary": "1b9ad6",
+      "quaternary": "e45735",
+      "header_background": "ffffff",
+      "header_primary": "333333",
+      "highlight": "ffff4d",
+      "danger": "e45735",
+      "success": "009900",
+      "love": "fa6c8d"
+    }
+  }
+}

--- a/about.json
+++ b/about.json
@@ -1,6 +1,7 @@
 {
   "name": "CSD Public Policy Hub",
   "about_url": "https://github.com/C-S-D/pph-theme/blob/master/README.md",
+  "license_url": "https://github.com/C-S-D/pph-theme/blob/master/LICENSE.txt",
   "color_schemes": {
     "CSD Public Policy Hub": {
       "primary": "333333",

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,0 +1,129 @@
+$pph-blue: #0575BB;
+$pph-blue-light: #1B9AD6;
+$pph-blue-dark: #1D293F;
+$pph-white: #FFFFFF;
+$pph-gray-light: #F7F7F7;
+$pph-gray: #999999;
+$pph-gray-dark: #4C4C4C;
+$pph-black: #333333;
+
+@mixin custom-font($font-name, $base-url) {
+  font-family: $font-name;
+  src: url("#{$base-url}.eot");
+  src: url("#{$base-url}.eot?#iefix") format('embedded-opentype'),
+       url("#{$base-url}.woff") format('woff'),
+       url("#{$base-url}.ttf") format('truetype'),
+       url("#{$base-url}.svg") format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  @include custom-font('WH_light', 'https://csdlegal-public-policy.s3.amazonaws.com/fonts/whitney/WhitneySSm-Light');
+}
+
+@font-face {
+  @include custom-font('WH_reg', 'https://csdlegal-public-policy.s3.amazonaws.com/fonts/whitney/WhitneySSm-Book');
+}
+
+@font-face {
+  @include custom-font('WH_reg_italic', 'https://csdlegal-public-policy.s3.amazonaws.com/fonts/whitney/WhitneySSm-BookItalic');
+}
+
+@font-face {
+  @include custom-font('WH_medium', 'https://csdlegal-public-policy.s3.amazonaws.com/fonts/whitney/WhitneySSm-Medium');
+}
+
+@font-face {
+  @include custom-font('WH_semibold', 'https://csdlegal-public-policy.s3.amazonaws.com/fonts/whitney/WhitneySSm-Semibold');
+}
+
+body {
+  font-family: 'WH_light', sans-serif;
+  font-size: 20px;
+  // Allow discourse to use the color pallet by not setting color here.
+}
+
+h1 {
+  color: $pph-black;
+  font-size: 40px;
+  font-weight: normal;
+  font-style: normal;
+}
+
+h2 {
+  $base-padding: 20px;
+  $border-style: 1px solid $pph-blue;
+  $border-height: 7px;
+  $border-margin: $base-padding - $border-height;
+
+  color: $pph-blue;
+  font-family: 'WH_reg', sans-serif;
+  font-size: 32px;
+  font-weight: normal;
+  font-style: normal;
+  text-align:center;
+  padding: $border-margin $base-padding;
+
+  &:before,
+  &:after {
+    border-left: $border-style;
+    border-right: $border-style;
+    content: '';
+    display: block;
+    padding: 0px;
+    height: $border-height;
+  }
+
+  &:before {
+    border-top: $border-style;
+    margin-bottom: $border-margin;
+  }
+
+  &:after {
+    border-bottom: $border-style;
+    margin-top: $border-margin;
+  }
+}
+
+h3 {
+  color: $pph-black;
+  font-family: 'WH_semibold', sans-serif;
+  font-size: 20px;
+  font-weight: normal;
+  font-style: normal;
+}
+
+h4 {
+  color: $pph-gray;
+  font-family: 'WH_medium', sans-serif;
+  font-size: 12px;
+  font-weight: normal;
+  font-style: normal;
+}
+
+a {
+  color: $pph-gray;
+  font-family: 'WH_light', sans-serif;
+
+  &:visited {
+    color: $pph-blue-light;
+  }
+}
+
+.topic-excerpt, .topic-body, .topic-post {
+  a {
+    color: $pph-blue-light;
+    font-family: 'WH_semibold', sans-serif;
+
+    &:visited {
+      color: $pph-gray;
+    }
+  }
+}
+
+.topic-excerpt, .topic-post {
+  color: $pph-gray;
+  font-family: 'WH_reg', sans-serif;
+  font-size: 12px;
+}

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2017 Communication Services for the Deaf, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 $pph-blue: #0575BB;
 $pph-blue-light: #1B9AD6;
 $pph-blue-dark: #1D293F;


### PR DESCRIPTION
I choose to add the Apache 2.0 license based on that pph-theme is public (I think it has to be unless we can provision GitHub access to production servers) and the fact that it includes limitations on use of trademark(s). I did this as a separate commit so we can easily drop or amend it.

SCSS Based on Style Guide attached to http://jira.csd.org/browse/PPH-13

![screenshot](https://user-images.githubusercontent.com/70075/32307640-e2703518-bf57-11e7-8d5c-669da3a0c27e.png)
