### PR TITLE
Override color for top nav bar

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -170,4 +170,13 @@ body {
     color: $pph-white;
     background-color: $pph-black;
   }
+
+  .extra-info-wrapper {
+    color: $pph-white;
+
+    .topic-link,
+    .topic-statuses i {
+      color: $pph-blue-light;
+    }
+  }
 }


### PR DESCRIPTION
The topics view places the topic title in the top nav bar. This is normally a white bar. We changed that to black so we also have to change the color to something better.

The Discourse styles have some specificity issues.